### PR TITLE
[bugbountyplatforms.md] Add Zero Day Initiative

### DIFF
--- a/cheatsheets/bugbountyplatforms.md
+++ b/cheatsheets/bugbountyplatforms.md
@@ -9,3 +9,4 @@
 - [Intigriti](https://intigriti.be/)
 - [Bugbountyjp](https://bugbounty.jp/)
 - [Yogosha](https://www.yogosha.com/)
+- [Zero Day Initiative](http://www.zerodayinitiative.com/)


### PR DESCRIPTION
Add Zero Day Initiative (ZDI, http://www.zerodayinitiative.com/) to bugbountyplatforms.md.