### PR TITLE
Removed PentestBox

### DIFF
--- a/cheatsheets/practice-platforms.md
+++ b/cheatsheets/practice-platforms.md
@@ -11,4 +11,3 @@
 - [OWASP Juice Shop](http://juice-shop.herokuapp.com/)
 - [Hack Yourself First](http://hackyourselffirst.troyhunt.com/)
 - [bWAPP](http://www.itsecgames.com/)
-- [Pentestbox](https://pentestbox.org/)


### PR DESCRIPTION
Pentestbox is not a practice platform, instead it contains a collection of tools which can be used for pentest.